### PR TITLE
Added NativeList<T> and FixedListXBytes<T> to the StubExtensions

### DIFF
--- a/LinqGen.Unity/Packages/com.cathei.linqgen/Runtime/Unity/StubExtensions.Unity.cs
+++ b/LinqGen.Unity/Packages/com.cathei.linqgen/Runtime/Unity/StubExtensions.Unity.cs
@@ -14,5 +14,41 @@ namespace Cathei.LinqGen
         {
             throw new NotImplementedException();
         }
+
+        public static Stub<IEnumerable<T>, Gen<NativeList<T>>> Gen<T>(this NativeList<T> enumerable)
+            where T : unmanaged
+        {
+            throw new NotImplementedException();
+        }
+
+        public static Stub<IEnumerable<T>, Gen<FixedList32Bytes<T>>> Gen<T>(this FixedList32Bytes<T> enumerable)
+            where T : unmanaged
+        {
+            throw new NotImplementedException();
+        }
+
+        public static Stub<IEnumerable<T>, Gen<FixedList64Bytes<T>>> Gen<T>(this FixedList64Bytes<T> enumerable)
+            where T : unmanaged
+        {
+            throw new NotImplementedException();
+        }
+
+        public static Stub<IEnumerable<T>, Gen<FixedList128Bytes<T>>> Gen<T>(this FixedList128Bytes<T> enumerable)
+            where T : unmanaged
+        {
+            throw new NotImplementedException();
+        }
+
+        public static Stub<IEnumerable<T>, Gen<FixedList512Bytes<T>>> Gen<T>(this FixedList512Bytes<T> enumerable)
+            where T : unmanaged
+        {
+            throw new NotImplementedException();
+        }
+
+        public static Stub<IEnumerable<T>, Gen<FixedList4096Bytes<T>>> Gen<T>(this FixedList4096Bytes<T> enumerable)
+            where T : unmanaged
+        {
+            throw new NotImplementedException();
+        }
     }
 }


### PR DESCRIPTION
Allows users to use the three most commonly used native collections without any additional work. Extending the class using an asmref is pretty straightforward and would be an acceptable compromise for custom types.